### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: c
 
-compiler:
-  - clang
-  - gcc
-
-env:
- - SCRIPT: 'make'
- - SCRIPT: 'make test'
- 
-script: "($SCRIPT)"
- 
+job: 
+  include:
+  - name: "Make GCC"
+    compiler: gcc
+    script: make --verbose
+  - name: "Make Clang"
+    compiler: clang
+    script: make test --verbose
+  - name: "Make test GCC"
+    compiler: gcc
+    script: make --verbose
+  - name: "Make test Clang"
+    compiler: clang
+    script: make test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ compiler:
   - gcc
 
 env:
- - SCRIPT: make
- - SCRIPT: make test
+ - SCRIPT: 'make
+ - SCRIPT: 'make test'
  
- script: $SCRIPT
+script: "($SCRIPT)"
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,12 @@
 language: c
+
+compiler:
+  - clang
+  - gcc
+
+env:
+ - SCRIPT: make
+ - SCRIPT: make test
+ 
+ script: $SCRIPT
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-job: 
+jobs: 
   include:
   - name: "Make GCC"
     compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - gcc
 
 env:
- - SCRIPT: 'make
+ - SCRIPT: 'make'
  - SCRIPT: 'make test'
  
 script: "($SCRIPT)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ jobs:
   include:
   - name: "Make GCC"
     compiler: gcc
-    script: make --verbose
+    script: make --debug
   - name: "Make Clang"
     compiler: clang
-    script: make test --verbose
+    script: make test --debug
   - name: "Make test GCC"
     compiler: gcc
-    script: make --verbose
+    script: make --debug
   - name: "Make test Clang"
     compiler: clang
-    script: make test --verbose
+    script: make test --debug

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# meshd
+# meshd [![Travis Build Status](https://travis-ci.org/loicpoulain/meshd.svg?branch=master)](https://travis-ci.org/loicpoulain/meshd)
 Bluetooth mesh stack POC for Linux
 In development...
 


### PR DESCRIPTION
This PR adds continuous integration with Travis. It builds & tests using the Makefile with both GCC and Clang compilers.

Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) in the GitHub Marketplace.